### PR TITLE
Bugfix for metadata filepath.Walk

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -233,6 +233,7 @@ func (v *volumeDriver) List(req volume.Request) (resp volume.Response) {
 	for _, vn := range vols {
 		resp.Volumes = append(resp.Volumes, v.volumeEntry(vn))
 	}
+	logctx.Debugf("response has %d items", len(resp.Volumes))
 	return
 }
 

--- a/metadata.go
+++ b/metadata.go
@@ -82,14 +82,23 @@ func (m *metadataDriver) Get(name string) (volumeMetadata, error) {
 
 func (m *metadataDriver) List() ([]string, error) {
 	var volumes []string
+
+	// return all the file names under metadata directory
 	if err := filepath.Walk(m.metaDir, func(path string, info os.FileInfo, inErr error) error {
 		if inErr != nil {
 			return inErr
 		}
-		if info.IsDir() {
+		if path == m.metaDir {
+			// directory itself, skip
+			return nil
+		}
+
+		if info.IsDir() { // a directory
 			return filepath.SkipDir
 		}
-		volumes = append(volumes, path)
+
+		// base file name indicates the volume name
+		volumes = append(volumes, filepath.Base(path))
 		return nil
 	}); err != nil {
 		return volumes, fmt.Errorf("cannot list directory: %v", err)


### PR DESCRIPTION
Fixes `docker volume ls` empty response issue.

Closes #20.
