### PR TITLE
Prevent leaking volume metadata

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -192,6 +192,13 @@ func (v *volumeDriver) Remove(req volume.Request) (resp volume.Response) {
 	} else {
 		logctx.Debugf("not removing share %q upon volume removal", share)
 	}
+
+	logctx.Debug("removing volume metadata")
+	if err != v.meta.Delete(req.Name) {
+		resp.Err = err.Error()
+		logctx.Error(resp.Err)
+		return
+	}
 	return
 }
 

--- a/metadata.go
+++ b/metadata.go
@@ -57,6 +57,13 @@ func (m *metadataDriver) Validate(meta map[string]string) (volumeMetadata, error
 			Share: meta["share"]}}, nil
 }
 
+func (m *metadataDriver) Delete(name string) error {
+	if err := os.RemoveAll(m.path(name)); err != nil {
+		return fmt.Errorf("cannot delete volume metadata: %v", err)
+	}
+	return nil
+}
+
 func (m *metadataDriver) Set(name string, meta volumeMetadata) error {
 	b, err := json.Marshal(meta)
 	if err != nil {


### PR DESCRIPTION
Caused removed volumes to still appear as existed as docker does not
keep list of volumes as of 1.10 (it queries the driver instead, which
relies on list of metadata for volumes). Deleting volume metadata
prevents this.

Closes #19.
