### PR TITLE
Do not remove mounted path recursivley after umount

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -155,7 +155,7 @@ func (v *volumeDriver) Unmount(req volume.Request) (resp volume.Response) {
 		logctx.Error(resp.Err)
 		return
 	}
-	if err := os.Remove(path); err != nil {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		resp.Err = fmt.Sprintf("error removing mountpoint: %v", err)
 		logctx.Error(resp.Err)
 		return

--- a/driver.go
+++ b/driver.go
@@ -155,7 +155,7 @@ func (v *volumeDriver) Unmount(req volume.Request) (resp volume.Response) {
 		logctx.Error(resp.Err)
 		return
 	}
-	if err := os.RemoveAll(path); err != nil {
+	if err := os.Remove(path); err != nil {
 		resp.Err = fmt.Sprintf("error removing mountpoint: %v", err)
 		logctx.Error(resp.Err)
 		return


### PR DESCRIPTION
Do not recursivly remove the mount-path after
unmounting it to prevent accidential data removal

Issue #23 
