### PR TITLE
Handle mountpoint removal in duplicate mounts

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -148,6 +150,7 @@ func (v *volumeDriver) Unmount(req volume.Request) (resp volume.Response) {
 		"operation": "unmount",
 		"name":      req.Name,
 	})
+
 	logctx.Debug("request accepted")
 	path := v.pathForVolume(req.Name)
 	if err := unmount(path); err != nil {
@@ -155,10 +158,35 @@ func (v *volumeDriver) Unmount(req volume.Request) (resp volume.Response) {
 		logctx.Error(resp.Err)
 		return
 	}
-	if err := os.RemoveAll(path); err != nil {
-		resp.Err = fmt.Sprintf("error removing mountpoint: %v", err)
+	logctx.Debug("unmount successful")
+
+	// Docker does not keep track of what is mounted and what is not, it will
+	// issue /Volume.Mount and /Volume.Unmount requests regardless when multiple
+	// containers use the same volume simulatenosly. This leads to duplicate
+	// mount entries and requirement for a careful cleanup of the mountpath in
+	// the following code.
+	//
+	// If same path is mounted multiple times, duplicate entries will occur
+	// in mount table for the same mountpoint. umount will remove the mount
+	// entry but the mountpoint will still be active (and mounted).
+	//
+	// In that case, we read the mount table to see if there is still something
+	// mounted, and only when there is nothing mounted, we remove the mountpoint
+	isActive, err := isMounted(path)
+	if err != nil {
+		resp.Err = err.Error()
 		logctx.Error(resp.Err)
 		return
+	}
+	if isActive {
+		logctx.Debug("mountpoint still has active mounts, not removing")
+	} else {
+		logctx.Debug("mountpoint has no further mounts, removing")
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			resp.Err = fmt.Sprintf("error removing mountpoint: %v", err)
+			logctx.Error(resp.Err)
+			return
+		}
 	}
 	return
 }
@@ -273,4 +301,51 @@ func unmount(mountpoint string) error {
 		return fmt.Errorf("unmount failed: %v\noutput=%q", err, out)
 	}
 	return nil
+}
+
+// isMounted reads /proc/self/mountinfo to see if the specified mountpoint is
+// mounted.
+func isMounted(mountpoint string) (bool, error) {
+	f, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return false, fmt.Errorf("cannot read mountinfo: %v", err)
+	}
+	defer f.Close()
+
+	// format of mountinfo:
+	//    38 23 0:30 / /sys/fs/cgroup/devices rw,relatime - cgroup cgroup rw,devices
+	//    39 23 0:31 / /sys/fs/cgroup/freezer rw,relatime - cgroup cgroup rw,freezer
+	//    33 22 8:17 / /mnt rw,relatime - ext4 /dev/sdb1 rw,data=ordered
+	// so we split the lines into the specified format and match the mountpoint
+	// at 5th field.
+	//
+	// This code is adopted from https://github.com/docker/docker/blob/master/pkg/mount/mountinfo_linux.go
+
+	oldFi, err := os.Stat(mountpoint)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("cannot stat mountpoint: %v", err)
+	}
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		t := s.Text()
+		f := strings.Fields(t)
+		if len(f) < 5 {
+			return false, fmt.Errorf("mountinfo line %q has less than 5 fields, cannot parse mountpoint", t)
+		}
+		mp := f[4] // ID, Parent, Major, Minor, Root, *Mountpoint*, Opts, OptionalFields
+		fi, err := os.Stat(mp)
+		if err != nil {
+			return false, fmt.Errorf("cannot stat %s: %v", mp, err)
+		}
+		same := os.SameFile(oldFi, fi)
+		if same {
+			return true, nil
+		}
+	}
+	log.Debug("mountpoint not found")
+	return false, nil
 }

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ const (
 func main() {
 	cmd := cli.NewApp()
 	cmd.Name = "azurefile-dockervolumedriver"
-	cmd.Version = "0.1"
+	cmd.Version = "0.2"
 	cmd.Usage = "Docker Volume Driver for Azure File Service"
 	cli.AppHelpTemplate = usageTemplate
 
@@ -62,7 +62,6 @@ func main() {
 		mountpoint := c.String("mountpoint")
 		metaDir := c.String("metadata")
 		removeShares := c.Bool("remove-shares")
-		bindAddr := c.String("bind")
 		if accountName == "" || accountKey == "" {
 			log.Fatal("azure storage account name and key must be provided.")
 		}
@@ -72,7 +71,7 @@ func main() {
 			"metadata":     metaDir,
 			"mountpoint":   mountpoint,
 			"removeShares": removeShares,
-		}).Debugf("Starting server at %s", bindAddr)
+		}).Debug("Starting server.")
 
 		driver, err := newVolumeDriver(accountName, accountKey, mountpoint, metaDir, removeShares)
 		if err != nil {


### PR DESCRIPTION
Docker does not keep track of what is mounted and what is not, it will
issue /Volume.Mount and /Volume.Unmount requests regardless when multiple
containers use the same volume simulatenosly. This leads to duplicate
mount entries and requirement for a careful cleanup of the mountpath in
this patch.

If same path is mounted multiple times, duplicate entries will occur
in mount table for the same mountpoint. These are mostly fine and harmless.
However umount will remove the mount entry and attempting to remove the
mountpoint at this time is not okay as it still has active mount(s).

In that case, we read the mount table to see if there is still something
mounted, and only when there is nothing mounted, we remove the mountpoint.

Fixes #23.

cc: @sascha-egerer 
