### PR TITLE
Add support for specifying uid, gid, filemode and dirmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,23 @@ This will create an Azure File Share named `myshare` (if it does not exist)
 and start a Docker container in which you can use `/data` directory to directly
 read/write from cloud file share location using SMB protocol.
 
-You can specify additional volume options to customize the owner, group, and permissions for
-files and directories. See the `mount.cifs(8)` man page more details on these options.
+You can specify additional volume options to customize the owner, group, and permissions for files and directories. See the `mount.cifs(8)` man page more details on these options.
+
+Options available:
+* `uid`
+* `gid`
+* `filemode`
+* `dirmode`
+* `nolock`
 
 ```shell
-$ docker volume create --name rabbitmq -d azurefile -o share=rabbitmq -o uid=999 -o gid=999 -o filemode=0600 -o dirmode=0755
+$ docker volume create -d azurefile \
+  -o share=sharename \
+  -o uid=999 \
+  -o gid=999 \
+  -o filemode=0600 \
+  -o dirmode=0755 \
+  -o nolock=true
 ```
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ read/write from cloud file share location using SMB protocol.
 
 You can specify additional volume options to customize the owner, group, and permissions for files and directories. See the `mount.cifs(8)` man page more details on these options.
 
-Options available:
+Mount Options Available:
 * `uid`
 * `gid`
 * `filemode`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Please check out the following documentation:
 #### Start volume driver daemon
 
 * Make sure you have a Storage Account on Azure (using Azure CLI or Portal).
-* The server process must be running on the host machine where Docker engine is installed on 
+* The server process must be running on the host machine where Docker engine is installed on
   at all times for volumes to work properly.
 * “cifs-utils” package must be installed on the host system as Azure Files use SMB protocol.
   For Debian/Ubuntu, run the following command on your host:
@@ -38,7 +38,7 @@ Please check out the following documentation:
 $ sudo apt-get install -y cifs-utils
 ```
 
-Please refer to “Installation” section above. If you like to build the binary from source, 
+Please refer to “Installation” section above. If you like to build the binary from source,
 see “Building” section below on how to compile. Once the driver is installed, start it and
 check its status.
 
@@ -66,6 +66,13 @@ $ docker run -it -v $(docker volume create -d azurefile -o share=myshare):/data 
 This will create an Azure File Share named `myshare` (if it does not exist)
 and start a Docker container in which you can use `/data` directory to directly
 read/write from cloud file share location using SMB protocol.
+
+You can specify additional volume options to customize the owner, group, and permissions for
+files and directories. See the `mount.cifs(8)` man page more details on these options.
+
+```shell
+$ docker volume create --name rabbitmq -d azurefile -o share=rabbitmq -o uid=999 -o gid=999 -o filemode=0600 -o dirmode=0755
+```
 
 ## Demo
 

--- a/driver.go
+++ b/driver.go
@@ -282,7 +282,6 @@ func (v *volumeDriver) pathForVolume(name string) string {
 }
 
 func mount(accountName, accountKey, mountpoint string, options VolumeOptions) error {
-	var opts []string
 	// Set defaults
 	if len(options.FileMode) == 0 {
 		options.FileMode = "0777"
@@ -297,14 +296,15 @@ func mount(accountName, accountKey, mountpoint string, options VolumeOptions) er
 		options.GID = "0"
 	}
 	mount := fmt.Sprintf("//%s.file.core.windows.net/%s", accountName, options.Share)
-	opts = append(opts, "vers=3.0")
-	opts = append(opts, fmt.Sprintf("username=%s", accountName))
-	opts = append(opts, fmt.Sprintf("password=%s", accountKey))
-	opts = append(opts, fmt.Sprintf("file_mode=%s", options.FileMode))
-	opts = append(opts, fmt.Sprintf("file_mode=%s", options.FileMode))
-	opts = append(opts, fmt.Sprintf("dir_mode=%s", options.DirMode))
-	opts = append(opts, fmt.Sprintf("uid=%s", options.UID))
-	opts = append(opts, fmt.Sprintf("gid=%s", options.GID))
+	opts := []string{
+		"vers=3.0",
+		fmt.Sprintf("username=%s", accountName),
+		fmt.Sprintf("password=%s", accountKey),
+		fmt.Sprintf("file_mode=%s", options.FileMode),
+		fmt.Sprintf("dir_mode=%s", options.DirMode),
+		fmt.Sprintf("uid=%s", options.UID),
+		fmt.Sprintf("gid=%s", options.GID),
+	}
 	if options.NoLock {
 		opts = append(opts, "nolock")
 	}

--- a/driver.go
+++ b/driver.go
@@ -133,7 +133,7 @@ func (v *volumeDriver) Mount(req volume.Request) (resp volume.Response) {
 		return
 	}
 
-	if err := mount(v.accountName, v.accountKey, meta.Options.Share, path); err != nil {
+	if err := mount(v.accountName, v.accountKey, path, meta.Options); err != nil {
 		resp.Err = err.Error()
 		logctx.Error(resp.Err)
 		return
@@ -281,12 +281,35 @@ func (v *volumeDriver) pathForVolume(name string) string {
 	return filepath.Join(v.mountpoint, name)
 }
 
-func mount(accountName, accountKey, shareName, mountpoint string) error {
+func mount(accountName, accountKey, mountpoint string, options VolumeOptions) error {
+	if len(options.FileMode) == 0 {
+		options.FileMode = "0777"
+	}
+	if len(options.DirMode) == 0 {
+		options.DirMode = "0777"
+	}
+	if len(options.UID) == 0 {
+		options.UID = "0"
+	}
+	if len(options.GID) == 0 {
+		options.GID = "0"
+	}
+	mount := fmt.Sprintf("//%s.file.core.windows.net/%s", accountName, options.Share)
+	opts := fmt.Sprintf(
+		"vers=3.0,username=%s,password=%s,dir_mode=%s,file_mode=%s,uid=%s,gid=%s",
+		accountName,
+		accountKey,
+		options.DirMode,
+		options.FileMode,
+		options.UID,
+		options.GID,
+	)
+
 	// TODO: replace with mount() syscall using docker/docker/pkg/mount
 	// (currently gives hard-to-debug 'invalid argument' error with the
 	// following arguments, my guess is, mount program does IP resolution
 	// and essentially passes a different set of options to system call).
-	cmd := exec.Command("mount", "-t", "cifs", fmt.Sprintf("//%s.file.core.windows.net/%s", accountName, shareName), mountpoint, "-o", fmt.Sprintf("vers=3.0,username=%s,password=%s,dir_mode=0777,file_mode=0777", accountName, accountKey), "--verbose")
+	cmd := exec.Command("mount", "-t", "cifs", mount, mountpoint, "-o", opts, "--verbose")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("mount failed: %v\noutput=%q", err, out)

--- a/metadata.go
+++ b/metadata.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	recognizedOptions = []string{"share"}
+	recognizedOptions = []string{"share", "filemode", "dirmode", "uid", "gid"}
 )
 
 type volumeMetadata struct {
@@ -21,7 +21,11 @@ type volumeMetadata struct {
 
 // VolumeOptions stores the opts passed to the driver by the docker engine.
 type VolumeOptions struct {
-	Share string `json:"share"`
+	Share    string `json:"share"`
+	FileMode string `json:"filemode"`
+	DirMode  string `json:"dirmode"`
+	UID      string `json:"uid"`
+	GID      string `json:"gid"`
 }
 
 type metadataDriver struct {
@@ -54,7 +58,13 @@ func (m *metadataDriver) Validate(meta map[string]string) (volumeMetadata, error
 
 	return volumeMetadata{
 		Options: VolumeOptions{
-			Share: meta["share"]}}, nil
+			Share:    meta["share"],
+			FileMode: meta["filemode"],
+			DirMode:  meta["dirmode"],
+			UID:      meta["uid"],
+			GID:      meta["gid"],
+		},
+	}, nil
 }
 
 func (m *metadataDriver) Delete(name string) error {

--- a/metadata.go
+++ b/metadata.go
@@ -63,7 +63,7 @@ func (m *metadataDriver) Validate(meta map[string]string) (volumeMetadata, error
 	opts.GID = meta["gid"]
 	opts.UID = meta["uid"]
 
-	if len(meta["nolock"]) > 0 {
+	if meta["nolock"] == "true" {
 		opts.NoLock = true
 	}
 

--- a/metadata.go
+++ b/metadata.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	recognizedOptions = []string{"share", "filemode", "dirmode", "uid", "gid"}
+	recognizedOptions = []string{"share", "filemode", "dirmode", "uid", "gid", "nolock"}
 )
 
 type volumeMetadata struct {
@@ -26,6 +26,7 @@ type VolumeOptions struct {
 	DirMode  string `json:"dirmode"`
 	UID      string `json:"uid"`
 	GID      string `json:"gid"`
+	NoLock   bool   `json:"nolock"`
 }
 
 type metadataDriver struct {
@@ -41,6 +42,7 @@ func newMetadataDriver(metaDir string) (*metadataDriver, error) {
 
 func (m *metadataDriver) Validate(meta map[string]string) (volumeMetadata, error) {
 	var v volumeMetadata
+	var opts VolumeOptions
 
 	// Validate keys
 	for k := range meta {
@@ -55,15 +57,18 @@ func (m *metadataDriver) Validate(meta map[string]string) (volumeMetadata, error
 			return v, fmt.Errorf("not a recognized volume driver option: %q", k)
 		}
 	}
+	opts.Share = meta["share"]
+	opts.DirMode = meta["dirmode"]
+	opts.FileMode = meta["filemode"]
+	opts.GID = meta["gid"]
+	opts.UID = meta["uid"]
+
+	if len(meta["nolock"]) > 0 {
+		opts.NoLock = true
+	}
 
 	return volumeMetadata{
-		Options: VolumeOptions{
-			Share:    meta["share"],
-			FileMode: meta["filemode"],
-			DirMode:  meta["dirmode"],
-			UID:      meta["uid"],
-			GID:      meta["gid"],
-		},
+		Options: opts,
 	}, nil
 }
 


### PR DESCRIPTION
There are quite a few docker library images that run their services as a non-privileged user instead of root and have security checks that fail if files/directories are world read/writable.  library/rabbitmq is an example. 

I've added in the ability to pass in the gid, uid, filemode and dirmode as options to volume create.
