### PR TITLE
Add RemotePath mount option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Mount Options Available:
 * `filemode`
 * `dirmode`
 * `nolock`
+* `remotepath`
 
 ```shell
 $ docker volume create -d azurefile \
@@ -83,7 +84,8 @@ $ docker volume create -d azurefile \
   -o gid=999 \
   -o filemode=0600 \
   -o dirmode=0755 \
-  -o nolock=true
+  -o nolock=true \
+  -o remotepath=directory
 ```
 
 ## Demo

--- a/driver.go
+++ b/driver.go
@@ -298,6 +298,13 @@ func mount(accountName, accountKey, storageBase, mountPath string, options Volum
 		options.GID = "0"
 	}
 	mountURI := fmt.Sprintf("//%s.file.%s/%s", accountName, storageBase, options.Share)
+        if len(options.RemotePath) != 0 {
+		if options.RemotePath[0] != '/' {
+			mountURI += "/"
+		}
+	mountURI += options.RemotePath
+        }
+
 	opts := []string{
 		"vers=3.0",
 		fmt.Sprintf("username=%s", accountName),

--- a/driver.go
+++ b/driver.go
@@ -298,12 +298,12 @@ func mount(accountName, accountKey, storageBase, mountPath string, options Volum
 		options.GID = "0"
 	}
 	mountURI := fmt.Sprintf("//%s.file.%s/%s", accountName, storageBase, options.Share)
-        if len(options.RemotePath) != 0 {
+	if len(options.RemotePath) != 0 {
 		if options.RemotePath[0] != '/' {
 			mountURI += "/"
 		}
-	mountURI += options.RemotePath
-        }
+		mountURI += options.RemotePath
+	}
 
 	opts := []string{
 		"vers=3.0",

--- a/driver.go
+++ b/driver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -299,10 +300,7 @@ func mount(accountName, accountKey, storageBase, mountPath string, options Volum
 	}
 	mountURI := fmt.Sprintf("//%s.file.%s/%s", accountName, storageBase, options.Share)
 	if len(options.RemotePath) != 0 {
-		if options.RemotePath[0] != '/' {
-			mountURI += "/"
-		}
-		mountURI += options.RemotePath
+		mountURI = path.Join(mountURI, options.RemotePath)
 	}
 
 	opts := []string{

--- a/metadata.go
+++ b/metadata.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	recognizedOptions = []string{"share", "filemode", "dirmode", "uid", "gid", "nolock"}
+	recognizedOptions = []string{"share", "filemode", "dirmode", "uid", "gid", "nolock", "remotepath"}
 )
 
 type volumeMetadata struct {
@@ -27,6 +27,7 @@ type VolumeOptions struct {
 	UID      string `json:"uid"`
 	GID      string `json:"gid"`
 	NoLock   bool   `json:"nolock"`
+	RemotePath string `json:"remotepath"`
 }
 
 type metadataDriver struct {
@@ -62,6 +63,7 @@ func (m *metadataDriver) Validate(meta map[string]string) (volumeMetadata, error
 	opts.FileMode = meta["filemode"]
 	opts.GID = meta["gid"]
 	opts.UID = meta["uid"]
+	opts.RemotePath =meta["remotepath"]
 
 	if meta["nolock"] == "true" {
 		opts.NoLock = true

--- a/metadata.go
+++ b/metadata.go
@@ -21,12 +21,12 @@ type volumeMetadata struct {
 
 // VolumeOptions stores the opts passed to the driver by the docker engine.
 type VolumeOptions struct {
-	Share    string `json:"share"`
-	FileMode string `json:"filemode"`
-	DirMode  string `json:"dirmode"`
-	UID      string `json:"uid"`
-	GID      string `json:"gid"`
-	NoLock   bool   `json:"nolock"`
+	Share      string `json:"share"`
+	FileMode   string `json:"filemode"`
+	DirMode    string `json:"dirmode"`
+	UID        string `json:"uid"`
+	GID        string `json:"gid"`
+	NoLock     bool   `json:"nolock"`
 	RemotePath string `json:"remotepath"`
 }
 
@@ -63,7 +63,7 @@ func (m *metadataDriver) Validate(meta map[string]string) (volumeMetadata, error
 	opts.FileMode = meta["filemode"]
 	opts.GID = meta["gid"]
 	opts.UID = meta["uid"]
-	opts.RemotePath =meta["remotepath"]
+	opts.RemotePath = meta["remotepath"]
 
 	if meta["nolock"] == "true" {
 		opts.NoLock = true

--- a/metadata.go
+++ b/metadata.go
@@ -63,6 +63,7 @@ func (m *metadataDriver) Validate(meta map[string]string) (volumeMetadata, error
 	opts.FileMode = meta["filemode"]
 	opts.GID = meta["gid"]
 	opts.UID = meta["uid"]
+	opts.RemotePath = meta["remotepath"]
 
 	if meta["nolock"] == "true" {
 		opts.NoLock = true

--- a/metadata.go
+++ b/metadata.go
@@ -63,7 +63,6 @@ func (m *metadataDriver) Validate(meta map[string]string) (volumeMetadata, error
 	opts.FileMode = meta["filemode"]
 	opts.GID = meta["gid"]
 	opts.UID = meta["uid"]
-	opts.RemotePath = meta["remotepath"]
 
 	if meta["nolock"] == "true" {
 		opts.NoLock = true


### PR DESCRIPTION
I add an option remotepath which will allow us to use a specific directory in File Share as a volume in the docker container.
