### PR TITLE
Fix storageBase shared as mountpoint

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -283,7 +283,7 @@ func (v *volumeDriver) pathForVolume(name string) string {
 	return filepath.Join(v.mountpoint, name)
 }
 
-func mount(accountName, accountKey, shareName, storageBase string, options VolumeOptions) error {
+func mount(accountName, accountKey, storageBase, mountPath string, options VolumeOptions) error {
 	// Set defaults
 	if len(options.FileMode) == 0 {
 		options.FileMode = "0777"
@@ -297,7 +297,7 @@ func mount(accountName, accountKey, shareName, storageBase string, options Volum
 	if len(options.GID) == 0 {
 		options.GID = "0"
 	}
-	mount := fmt.Sprintf("//%s.file.%s/%s", accountName, storageBase, options.Share)
+	mountURI := fmt.Sprintf("//%s.file.%s/%s", accountName, storageBase, options.Share)
 	opts := []string{
 		"vers=3.0",
 		fmt.Sprintf("username=%s", accountName),
@@ -315,7 +315,7 @@ func mount(accountName, accountKey, shareName, storageBase string, options Volum
 	// (currently gives hard-to-debug 'invalid argument' error with the
 	// following arguments, my guess is, mount program does IP resolution
 	// and essentially passes a different set of options to system call).
-	cmd := exec.Command("mount", "-t", "cifs", mount, mountpoint, "-o", strings.Join(opts, ","), "--verbose")
+	cmd := exec.Command("mount", "-t", "cifs", mountURI, mountPath, "-o", strings.Join(opts, ","), "--verbose")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("mount failed: %v\noutput=%q", err, out)


### PR DESCRIPTION
It appears like #43 has broken the mount command as we passed
storageBase as mountPath to the mount() method.

Fixes #47.
