### PR TITLE
Get version info automatically from git env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ install:
 - export GO15VENDOREXPERIMENT=1
 before_script:
 - go get -u github.com/golang/lint/golint
-go: 1.5
+- go get -u github.com/ahmetalpbalkan/govvv
+go: 1.7
 script:
 - test -z "$(gofmt -s -l -w . | tee /dev/stderr)"
 - test -z "$(golint . |  tee /dev/stderr)"
 - go vet .
-- GOOS=linux GOARCH=amd64 go build -v -o bin/azurefile-dockervolumedriver .
+- GOOS=linux GOARCH=amd64 govvv build -v -o bin/azurefile-dockervolumedriver .
 - go list ./... | grep -v '/vendor/' | xargs go test -v
 deploy:
   provider: releases

--- a/main.go
+++ b/main.go
@@ -15,10 +15,17 @@ const (
 	metadataRoot     = "/etc/docker/plugins/azurefile/volumes"
 )
 
+var (
+	// GitSummary is provided at compile-time when built with govvv.
+	// If the source tree corresponds to a tag, the tag name is used.
+	// Otherwise, provides a string summarizing the state of git tree.
+	GitSummary string
+)
+
 func main() {
 	cmd := cli.NewApp()
 	cmd.Name = "azurefile-dockervolumedriver"
-	cmd.Version = "0.2.1"
+	cmd.Version = GitSummary
 	cmd.Usage = "Docker Volume Driver for Azure File Service"
 	cli.AppHelpTemplate = usageTemplate
 


### PR DESCRIPTION
Past quite a few releases we forgot to update the Version field
showed up in --help.

Switching to govvv to provide version info automatically at
compile time. For binary releases on GitHub releases tab,
this will automatically contain the tag name and nothing else.

Fixes #54, fixes #56.
