### PR TITLE
Add support for symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ link above. The following instructions are for compiling the project from source
 In order to compile this program, you need to have Go 1.6:
 
 ```sh
-$ git clone https://github.com/Azure/azurefile-dockervolumedriver src/azurefile
+$ git clone https://github.com/Azure/azurefile-dockervolumedriver src/azurefile-dockervolumedriver
 $ export GOPATH=`pwd`
-$ cd src/azurefile
+$ cd src/azurefile-dockervolumedriver
 $ go build
 $ ./azurefile-dockervolumedriver -h
 ```

--- a/driver.go
+++ b/driver.go
@@ -315,6 +315,7 @@ func mount(accountName, accountKey, storageBase, mountPath string, options Volum
 		fmt.Sprintf("dir_mode=%s", options.DirMode),
 		fmt.Sprintf("uid=%s", options.UID),
 		fmt.Sprintf("gid=%s", options.GID),
+		"mfsymlinks",
 	}
 	if options.NoLock {
 		opts = append(opts, "nolock")


### PR DESCRIPTION
Add the `mfsymlinks` option when mounting the volume to support symbolic links.