### PR TITLE
Add docker self-contain plugin, default share name, nobrl and cache

### DIFF
--- a/.docker/plugin/Dockerfile
+++ b/.docker/plugin/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.6
+
+RUN apk --update add ca-certificates cifs-utils
+RUN mkdir -p /run/docker/plugins /var/lib/azurefile/volumes
+
+ADD azurefile-dockervolumedriver /usr/bin/azurefile-dockervolumedriver
+# ADD start.sh /start.sh
+
+# ENTRYPOINT [ "/start.sh" ]
+CMD [ "azurefile-dockervolumedriver" ]

--- a/.docker/plugin/Dockerfile
+++ b/.docker/plugin/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.6
 
 RUN apk --update add ca-certificates cifs-utils
-RUN mkdir -p /run/docker/plugins /var/lib/azurefile/volumes
+RUN mkdir -p /run/docker/plugins /var/run/docker/volumedriver/azurefile
 
 ADD azurefile-dockervolumedriver /usr/bin/azurefile-dockervolumedriver
 # ADD start.sh /start.sh

--- a/.docker/plugin/config.json
+++ b/.docker/plugin/config.json
@@ -1,0 +1,64 @@
+{
+    "Args": {
+      "Description": "",
+      "Name": "",
+      "Settable": null,
+      "Value": null
+    },
+    "Description": "Volume plugin for Azure File Storage",
+    "Documentation": "https://github.com/jmaitrehenry/azurefile-dockervolumedriver/.docker/plugin",
+    "Entrypoint": [
+      "azurefile-dockervolumedriver"
+    ],
+    "Env": [
+      {
+        "Description": "Azure storage account name",
+        "Name": "AZURE_STORAGE_ACCOUNT",
+        "Settable": [
+          "value"
+        ],
+        "Value": ""
+      },
+      {
+        "Description": "Azure storage account key",
+        "Name": "AZURE_STORAGE_ACCOUNT_KEY",
+        "Settable": [
+          "value"
+        ],
+        "Value": ""
+      },
+      {
+        "Description": "Enable verbose logging",
+        "Name": "DEBUG",
+        "Settable": [
+          "value"
+        ],
+        "Value": ""
+      }
+    ],
+    "Interface": {
+      "Socket": "azurefile.sock",
+      "Types": [
+        "docker.volumedriver/1.0"
+      ]
+    },
+    "Linux": {
+      "AllowAllDevices": true,
+      "Capabilities": ["CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_DAC_READ_SEARCH"],
+      "Devices": null
+    },
+    "Mounts": [
+      {
+        "Source": "/dev",
+        "Destination": "/dev",
+        "Type": "bind",
+        "Options": ["rbind"]
+      }
+    ],
+    "Network": {
+      "Type": "host"
+    },
+    "PropagatedMount": "/var/lib/azurefile",
+    "User": {},
+    "WorkDir": ""
+}

--- a/.docker/plugin/config.json
+++ b/.docker/plugin/config.json
@@ -58,7 +58,7 @@
     "Network": {
       "Type": "host"
     },
-    "PropagatedMount": "/var/lib/azurefile",
+    "PropagatedMount": "/var/run/docker/volumedriver/azurefile",
     "User": {},
     "WorkDir": ""
 }

--- a/driver.go
+++ b/driver.go
@@ -324,7 +324,7 @@ func mount(accountName, accountKey, storageBase, mountPath string, options Volum
 	// (currently gives hard-to-debug 'invalid argument' error with the
 	// following arguments, my guess is, mount program does IP resolution
 	// and essentially passes a different set of options to system call).
-	cmd := exec.Command("mount", "-t", "cifs", mountURI, mountPath, "-o", strings.Join(opts, ","), "--verbose")
+	cmd := exec.Command("mount", "-t", "cifs", mountURI, mountPath, "-v", "-o", strings.Join(opts, ","))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("mount failed: %v\noutput=%q", err, out)

--- a/driver.go
+++ b/driver.go
@@ -316,8 +316,17 @@ func mount(accountName, accountKey, storageBase, mountPath string, options Volum
 		fmt.Sprintf("uid=%s", options.UID),
 		fmt.Sprintf("gid=%s", options.GID),
 	}
+
+	if len(options.Cache) > 0 {
+		opts = append(opts, fmt.Sprintf("cache=%s", options.Cache))
+	}
+
 	if options.NoLock {
 		opts = append(opts, "nolock")
+	}
+
+	if options.NoBrl {
+		opts = append(opts, "nobrl")
 	}
 
 	// TODO: replace with mount() syscall using docker/docker/pkg/mount

--- a/driver.go
+++ b/driver.go
@@ -60,7 +60,7 @@ func (v *volumeDriver) Create(req volume.Request) (resp volume.Response) {
 		"name":      req.Name,
 		"options":   req.Options})
 
-	volMeta, err := v.meta.Validate(req.Options)
+	volMeta, err := v.meta.Validate(req.Options, req.Name)
 	if err != nil {
 		resp.Err = fmt.Sprintf("error validating metadata: %v", err)
 		logctx.Error(resp.Err)
@@ -71,7 +71,7 @@ func (v *volumeDriver) Create(req volume.Request) (resp volume.Response) {
 	volMeta.Account = v.accountName
 	volMeta.CreatedAt = time.Now().UTC()
 
-	share := req.Options["share"]
+	share := volMeta.Options.Share
 	if share == "" {
 		resp.Err = "missing volume option: 'share'"
 		logctx.Error(resp.Err)

--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+sudo rm -rf .docker/plugin/rootfs
+mkdir .docker/plugin/rootfs
+
+GOOS=linux GOARCH=amd64 go build
+cp azurefile-dockervolumedriver .docker/plugin/
+
+docker build -t rootfsimage .docker/plugin
+id=`docker create rootfsimage true`
+
+docker export $id |sudo tar -x -C .docker/plugin/rootfs
+
+docker plugin rm jmaitrehenry/azurefile
+sudo docker plugin create jmaitrehenry/azurefile .docker/plugin
+docker plugin push jmaitrehenry/azurefile

--- a/metadata.go
+++ b/metadata.go
@@ -41,7 +41,7 @@ func newMetadataDriver(metaDir string) (*metadataDriver, error) {
 	return &metadataDriver{metaDir}, nil
 }
 
-func (m *metadataDriver) Validate(meta map[string]string) (volumeMetadata, error) {
+func (m *metadataDriver) Validate(meta map[string]string, name string) (volumeMetadata, error) {
 	var v volumeMetadata
 	var opts VolumeOptions
 
@@ -58,6 +58,11 @@ func (m *metadataDriver) Validate(meta map[string]string) (volumeMetadata, error
 			return v, fmt.Errorf("not a recognized volume driver option: %q", k)
 		}
 	}
+
+	if meta["share"] == "" {
+		meta["share"] = name
+	}
+
 	opts.Share = meta["share"]
 	opts.DirMode = meta["dirmode"]
 	opts.FileMode = meta["filemode"]

--- a/metadata.go
+++ b/metadata.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	recognizedOptions = []string{"share", "filemode", "dirmode", "uid", "gid", "nolock", "remotepath"}
+	recognizedOptions = []string{"share", "filemode", "dirmode", "uid", "gid", "nolock", "remotepath", "cache", "nobrl"}
 )
 
 type volumeMetadata struct {
@@ -26,7 +26,9 @@ type VolumeOptions struct {
 	DirMode    string `json:"dirmode"`
 	UID        string `json:"uid"`
 	GID        string `json:"gid"`
+	Cache      string `json:"cache"`
 	NoLock     bool   `json:"nolock"`
+	NoBrl      bool   `json:"nobrl"`
 	RemotePath string `json:"remotepath"`
 }
 
@@ -70,8 +72,16 @@ func (m *metadataDriver) Validate(meta map[string]string, name string) (volumeMe
 	opts.UID = meta["uid"]
 	opts.RemotePath = meta["remotepath"]
 
+	if len(meta["cache"]) > 0 {
+		opts.Cache = meta["cache"]
+	}
+
 	if meta["nolock"] == "true" {
 		opts.NoLock = true
+	}
+
+	if meta["nobrl"] == "true" {
+		opts.NoBrl = true
 	}
 
 	return volumeMetadata{


### PR DESCRIPTION
Hi,

I made the following changes:
- Add the possibility to build a self-contain docker volume plugin
- Add default share name to volume name
- Add nobrl and cache option
- Change --verbose to -v and put it before -o in the mount instruction for some Linux (like Alpine)

I will update the readme for adding the new options.

If you want to try the plugin:
```sh
$ docker plugin install jmaitrehenry/azurefile DEBUG=true AZURE_STORAGE_ACCOUNT=xxx AZURE_STORAGE_ACCOUNT_KEY=yyy

Plugin "jmaitrehenry/azurefile" is requesting the following privileges:
 - network: [host]
 - mount: [/dev]
 - allow-all-devices: [true]
 - capabilities: [CAP_SYS_ADMIN CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH]
Do you grant the above permissions? [y/N] y
latest: Pulling from jmaitrehenry/azurefile
5ed404b172dd: Download complete
Digest: sha256:22de2d8a6a9750b59750663d781ead0cb5bff4519f0cd7ebea80bfeae071112d
Status: Downloaded newer image for jmaitrehenry/azurefile:latest
Installed plugin jmaitrehenry/azurefile

$ docker volume create --name nobrl -d jmaitrehenry/azurefile -o nobrl=true
$ docker run --rm -ti -v nobrl:/nobrl alpine
```